### PR TITLE
New action that runs Cypress tests from API Service repos

### DIFF
--- a/cypress-api-service-testing/run-cypress-tests/action.yaml
+++ b/cypress-api-service-testing/run-cypress-tests/action.yaml
@@ -52,7 +52,7 @@ runs:
 
     - name: Generate unique ID
       shell: bash
-      run: echo "::set-env name=SHAGUID::sha-$GITHUB_SHA-time-$(date +"%s")"
+      run: echo "SHAGUID=sha-$GITHUB_SHA-time-$(date +"%s")" >> $GITHUB_ENV
 
     - name: Run Tests
       uses: cypress-io/github-action@v2

--- a/cypress-api-service-testing/run-cypress-tests/action.yaml
+++ b/cypress-api-service-testing/run-cypress-tests/action.yaml
@@ -67,7 +67,7 @@ runs:
         echo "---------->${GITHUB_REPOSITORY}<----------"
 
     - name: Run Tests
-      uses: jdborneman-terminus/cypress-io-github-action@049562e07b387271ce9ef383a5050cb4a337ef77
+      uses: jdborneman-terminus/cypress-io-github-action@c6a138e
       with:
         config: video=true
         command-prefix: yarn

--- a/cypress-api-service-testing/run-cypress-tests/action.yaml
+++ b/cypress-api-service-testing/run-cypress-tests/action.yaml
@@ -62,7 +62,7 @@ runs:
 
     - name: Echo GITHUB_REPOSITORY
       shell: bash
-      run: echo "---------->${{ env.GITHUB_REPOSITORY }}<----------"
+      run: echo "---------->${GITHUB_REPOSITORY}<----------"
 
     - name: Run Tests
       uses: cypress-io/github-action@v2

--- a/cypress-api-service-testing/run-cypress-tests/action.yaml
+++ b/cypress-api-service-testing/run-cypress-tests/action.yaml
@@ -62,7 +62,9 @@ runs:
 
     - name: Echo GITHUB_REPOSITORY
       shell: bash
-      run: echo "---------->${GITHUB_REPOSITORY}<----------"
+      run: |
+        cd ${{ inputs.repo_cypress_dir }}
+        echo "---------->${GITHUB_REPOSITORY}<----------"
 
     - name: Run Tests
       uses: cypress-io/github-action@v2

--- a/cypress-api-service-testing/run-cypress-tests/action.yaml
+++ b/cypress-api-service-testing/run-cypress-tests/action.yaml
@@ -45,10 +45,14 @@ runs:
         token: ${{ inputs.repo_checkout_token }}
 
     - name: Yarn Install
-      uses: shell
       run: |
         cd ${{ inputs.repo_cypress_dir }}
         yarn install
+      shell: bash
+
+    - name: Generate unique ID
+      shell: bash
+      run: echo "::set-env name=SHAGUID::sha-$GITHUB_SHA-time-$(date +"%s")"
 
     - name: Run Tests
       uses: cypress-io/github-action@v2
@@ -61,7 +65,7 @@ runs:
         record: true
         parallel: true
         working-directory: ${{ github.events.inputs.repo_cypress_dir }}
-        ci-build-id: ${{ needs.prepare.outputs.uuid }}
+        ci-build-id: ${{ env.SHAGUID }}
       env:
         CYPRESS_RECORD_KEY: ${{ github.event.inputs.cypress_record_key}}
         YARN_NODE_LINKER: pnp

--- a/cypress-api-service-testing/run-cypress-tests/action.yaml
+++ b/cypress-api-service-testing/run-cypress-tests/action.yaml
@@ -47,7 +47,7 @@ runs:
     - name: Yarn Install
       run: |
         ls -lah
-        cd "${{ inputs.repo }}/${{ ${{ inputs.repo_cypress_dir }}"
+        cd "${{ inputs.repo }}/${{ inputs.repo_cypress_dir }}"
         yarn install
       shell: bash
 
@@ -65,11 +65,11 @@ runs:
         tag: 'API-${{ inputs.cypress_browser }},${{ inputs.environment }}'
         record: true
         parallel: true
-        working-directory: "${{ inputs.repo }}/${{ ${{ inputs.repo_cypress_dir }}"
+        working-directory: "${{ inputs.repo }}/${{ inputs.repo_cypress_dir }}"
         ci-build-id: ${{ env.SHAGUID }}
       env:
         CYPRESS_RECORD_KEY: ${{ inputs.cypress_record_key}}
         YARN_NODE_LINKER: pnp
-        CYPRESS_grepTags: ${{ test_tags }}
+        CYPRESS_grepTags: ${{ inputs.test_tags }}
         DD_ENV: ${{ inputs.environment }}
         DD_SERVICE: ${{ inputs.repo }}

--- a/cypress-api-service-testing/run-cypress-tests/action.yaml
+++ b/cypress-api-service-testing/run-cypress-tests/action.yaml
@@ -67,7 +67,7 @@ runs:
         echo "---------->${GITHUB_REPOSITORY}<----------"
 
     - name: Run Tests
-      uses: jdborneman-terminus/cypress-io-github-action@c6a138e9c9753ab20e69d0569cfcb489518da64a
+      uses: jdborneman-terminus/cypress-io-github-action@00b530b3de035e8724c5ed3e35f1ee445e8916e5
       with:
         config: video=true
         command-prefix: yarn

--- a/cypress-api-service-testing/run-cypress-tests/action.yaml
+++ b/cypress-api-service-testing/run-cypress-tests/action.yaml
@@ -50,21 +50,6 @@ runs:
         cd ${{ inputs.repo_cypress_dir }}
         yarn install
 
-    - name: Parse Env vars
-      uses: sergeysova/jq-action@v2
-      id: environment_vars
-      with:
-        cmd: 'jq ''.[] | .var'' ${{ environment_vars }} -r'
-        multline: true
-    
-    - name: Set Env vars
-      uses: shell
-      run: |
-        environment_vars="${{ steps.environment_vars.outputs.value }}"
-        for environment_var in $environment_vars; do
-          export "$environment_var"
-        done
-
     - name: Run Tests
       uses: cypress-io/github-action@v2
       with:

--- a/cypress-api-service-testing/run-cypress-tests/action.yaml
+++ b/cypress-api-service-testing/run-cypress-tests/action.yaml
@@ -61,7 +61,7 @@ runs:
         echo "CYDIR=$(pwd)" >> $GITHUB_ENV
 
     - name: Run Tests
-      uses: jdborneman-terminus/cypress-io-github-action@6b4776ce07d9ded26846e8ffb9680ef0034556e5
+      uses: cypress-io/github-action@e1028255ee17f0c0f405ef8867675a165a086971
       with:
         config: video=true
         command-prefix: yarn

--- a/cypress-api-service-testing/run-cypress-tests/action.yaml
+++ b/cypress-api-service-testing/run-cypress-tests/action.yaml
@@ -67,7 +67,7 @@ runs:
         echo "---------->${GITHUB_REPOSITORY}<----------"
 
     - name: Run Tests
-      uses: jdborneman-terminus/cypress-io-github-action
+      uses: jdborneman-terminus/cypress-io-github-action@049562e07b387271ce9ef383a5050cb4a337ef77
       with:
         config: video=true
         command-prefix: yarn

--- a/cypress-api-service-testing/run-cypress-tests/action.yaml
+++ b/cypress-api-service-testing/run-cypress-tests/action.yaml
@@ -62,7 +62,7 @@ runs:
 
     - name: Echo GITHUB_REPOSITORY
       shell: bash
-      run: echo "---------->$GITHUB_REPOSITORY<----------""
+      run: echo "---------->${{ env.GITHUB_REPOSITORY }}<----------"
 
     - name: Run Tests
       uses: cypress-io/github-action@v2

--- a/cypress-api-service-testing/run-cypress-tests/action.yaml
+++ b/cypress-api-service-testing/run-cypress-tests/action.yaml
@@ -46,7 +46,8 @@ runs:
 
     - name: Yarn Install
       run: |
-        cd ${{ inputs.repo_cypress_dir }}
+        ls -lah
+        cd "${{ inputs.repo }}/${{ ${{ inputs.repo_cypress_dir }}"
         yarn install
       shell: bash
 
@@ -59,16 +60,16 @@ runs:
       with:
         config: video=true
         command-prefix: yarn
-        browser: ${{ github.event.inputs.cypress_browser }}
+        browser: ${{ inputs.cypress_browser }}
         headless: true
-        tag: 'API-${{ github.event.inputs.cypress_browser }},${{ github.event.inputs.environment }}'
+        tag: 'API-${{ inputs.cypress_browser }},${{ inputs.environment }}'
         record: true
         parallel: true
-        working-directory: ${{ github.events.inputs.repo_cypress_dir }}
+        working-directory: "${{ inputs.repo }}/${{ ${{ inputs.repo_cypress_dir }}"
         ci-build-id: ${{ env.SHAGUID }}
       env:
-        CYPRESS_RECORD_KEY: ${{ github.event.inputs.cypress_record_key}}
+        CYPRESS_RECORD_KEY: ${{ inputs.cypress_record_key}}
         YARN_NODE_LINKER: pnp
-        CYPRESS_grepTags: ${{ github.event.inputs.test_tags }}
-        DD_ENV: ${{ github.event.inputs.environment }}
+        CYPRESS_grepTags: ${{ test_tags }}
+        DD_ENV: ${{ inputs.environment }}
         DD_SERVICE: ${{ inputs.repo }}

--- a/cypress-api-service-testing/run-cypress-tests/action.yaml
+++ b/cypress-api-service-testing/run-cypress-tests/action.yaml
@@ -61,7 +61,7 @@ runs:
         echo "CYDIR=$(pwd)" >> $GITHUB_ENV
 
     - name: Run Tests
-      uses: cypress-io/github-action@e1028255ee17f0c0f405ef8867675a165a086971
+      uses: cypress-io/github-action@v3
       with:
         config: video=true
         command-prefix: yarn

--- a/cypress-api-service-testing/run-cypress-tests/action.yaml
+++ b/cypress-api-service-testing/run-cypress-tests/action.yaml
@@ -61,7 +61,7 @@ runs:
         echo "CYDIR=$(pwd)" >> $GITHUB_ENV
 
     - name: Run Tests
-      uses: jdborneman-terminus/cypress-io-github-action@c179631d629e64a3837ec00b2a7a1357b528592b
+      uses: jdborneman-terminus/cypress-io-github-action@6b4776ce07d9ded26846e8ffb9680ef0034556e5
       with:
         config: video=true
         command-prefix: yarn

--- a/cypress-api-service-testing/run-cypress-tests/action.yaml
+++ b/cypress-api-service-testing/run-cypress-tests/action.yaml
@@ -67,7 +67,7 @@ runs:
         echo "---------->${GITHUB_REPOSITORY}<----------"
 
     - name: Run Tests
-      uses: cypress-io/github-action@v2
+      uses: jdborneman-terminus/cypress-io-github-action
       with:
         config: video=true
         command-prefix: yarn

--- a/cypress-api-service-testing/run-cypress-tests/action.yaml
+++ b/cypress-api-service-testing/run-cypress-tests/action.yaml
@@ -85,4 +85,4 @@ runs:
         DD_ENV: ${{ inputs.environment }}
         DD_SERVICE: ${{ inputs.repo }}
         DEBUG: '@cypress/github-action'
-        GITHUB_REPOSITORY: 'GetTerminus/oauth_service_infra'
+        GITHUB_REPOSITORY: '${{ inputs.repo_owner }}/${{ inputs.repo }}'

--- a/cypress-api-service-testing/run-cypress-tests/action.yaml
+++ b/cypress-api-service-testing/run-cypress-tests/action.yaml
@@ -60,14 +60,8 @@ runs:
         cd ${{ inputs.repo_cypress_dir }}
         echo "CYDIR=$(pwd)" >> $GITHUB_ENV
 
-    - name: Echo GITHUB_REPOSITORY
-      shell: bash
-      run: |
-        cd ${{ inputs.repo_cypress_dir }}
-        echo "---------->${GITHUB_REPOSITORY}<----------"
-
     - name: Run Tests
-      uses: jdborneman-terminus/cypress-io-github-action@00b530b3de035e8724c5ed3e35f1ee445e8916e5
+      uses: jdborneman-terminus/cypress-io-github-action@4b8d0b2d90aa41cd05cdfce5386e6e382c49a2e2
       with:
         config: video=true
         command-prefix: yarn

--- a/cypress-api-service-testing/run-cypress-tests/action.yaml
+++ b/cypress-api-service-testing/run-cypress-tests/action.yaml
@@ -67,7 +67,7 @@ runs:
         echo "---------->${GITHUB_REPOSITORY}<----------"
 
     - name: Run Tests
-      uses: jdborneman-terminus/cypress-io-github-action@c6a138e
+      uses: jdborneman-terminus/cypress-io-github-action@c6a138e9c9753ab20e69d0569cfcb489518da64a
       with:
         config: video=true
         command-prefix: yarn

--- a/cypress-api-service-testing/run-cypress-tests/action.yaml
+++ b/cypress-api-service-testing/run-cypress-tests/action.yaml
@@ -26,7 +26,7 @@ inputs:
     description: 'The browser to test against'
     required: false
     default: 'chrome'
-  test_tags:
+  cypress_test_tags:
     description: 'Cypress tags to run'
     required: false
     default: '@SMOKE'
@@ -74,7 +74,7 @@ runs:
       env:
         CYPRESS_RECORD_KEY: ${{ inputs.cypress_record_key}}
         YARN_NODE_LINKER: pnp
-        CYPRESS_grepTags: ${{ inputs.test_tags }}
+        CYPRESS_grepTags: ${{ inputs.cypress_test_tags }}
         DD_ENV: ${{ inputs.environment }}
         DD_SERVICE: ${{ inputs.repo }}
         DEBUG: '@cypress/github-action'

--- a/cypress-api-service-testing/run-cypress-tests/action.yaml
+++ b/cypress-api-service-testing/run-cypress-tests/action.yaml
@@ -78,3 +78,4 @@ runs:
         CYPRESS_grepTags: ${{ inputs.test_tags }}
         DD_ENV: ${{ inputs.environment }}
         DD_SERVICE: ${{ inputs.repo }}
+        DEBUG: '@cypress/github-action'

--- a/cypress-api-service-testing/run-cypress-tests/action.yaml
+++ b/cypress-api-service-testing/run-cypress-tests/action.yaml
@@ -23,7 +23,7 @@ inputs:
     required: false
     default: 'cypress-e2e'
   cypress_browser:
-    description: 'The browsers to test against'
+    description: 'The browser to test against'
     required: false
     default: 'chrome'
   test_tags:
@@ -49,10 +49,6 @@ runs:
         cd ${{ inputs.repo_cypress_dir }}
         yarn install
       shell: bash
-
-    - name: Generate unique ID
-      shell: bash
-      run: echo "SHAGUID=sha-$GITHUB_SHA-time-$(date +"%s")" >> $GITHUB_ENV
     
     - name: Get working directory for tests
       shell: bash
@@ -71,7 +67,7 @@ runs:
         record: true
         parallel: true
         working-directory: ${{ env.CYDIR }}
-        ci-build-id: ${{ env.SHAGUID }}
+        ci-build-id: ${{ github.run_id }}
       env:
         CYPRESS_RECORD_KEY: ${{ inputs.cypress_record_key}}
         YARN_NODE_LINKER: pnp

--- a/cypress-api-service-testing/run-cypress-tests/action.yaml
+++ b/cypress-api-service-testing/run-cypress-tests/action.yaml
@@ -60,6 +60,10 @@ runs:
         cd ${{ inputs.repo_cypress_dir }}
         echo "CYDIR=$(pwd)" >> $GITHUB_ENV
 
+    - name: Echo GITHUB_REPOSITORY
+      shell: bash
+      run: echo "---------->$GITHUB_REPOSITORY<----------""
+
     - name: Run Tests
       uses: cypress-io/github-action@v2
       with:

--- a/cypress-api-service-testing/run-cypress-tests/action.yaml
+++ b/cypress-api-service-testing/run-cypress-tests/action.yaml
@@ -46,8 +46,7 @@ runs:
 
     - name: Yarn Install
       run: |
-        ls -lah
-        cd "${{ inputs.repo }}/${{ inputs.repo_cypress_dir }}"
+        cd ${{ inputs.repo_cypress_dir }}
         yarn install
       shell: bash
 
@@ -65,7 +64,7 @@ runs:
         tag: 'API-${{ inputs.cypress_browser }},${{ inputs.environment }}'
         record: true
         parallel: true
-        working-directory: "${{ inputs.repo }}/${{ inputs.repo_cypress_dir }}"
+        working-directory: ${{ inputs.repo_cypress_dir }}
         ci-build-id: ${{ env.SHAGUID }}
       env:
         CYPRESS_RECORD_KEY: ${{ inputs.cypress_record_key}}

--- a/cypress-api-service-testing/run-cypress-tests/action.yaml
+++ b/cypress-api-service-testing/run-cypress-tests/action.yaml
@@ -85,3 +85,4 @@ runs:
         DD_ENV: ${{ inputs.environment }}
         DD_SERVICE: ${{ inputs.repo }}
         DEBUG: '@cypress/github-action'
+        GITHUB_REPOSITORY: 'GetTerminus/oauth_service_infra'

--- a/cypress-api-service-testing/run-cypress-tests/action.yaml
+++ b/cypress-api-service-testing/run-cypress-tests/action.yaml
@@ -53,6 +53,12 @@ runs:
     - name: Generate unique ID
       shell: bash
       run: echo "SHAGUID=sha-$GITHUB_SHA-time-$(date +"%s")" >> $GITHUB_ENV
+    
+    - name: Get working directory for tests
+      shell: bash
+      run: |
+        cd ${{ inputs.repo_cypress_dir }}
+        echo "CYDIR=$(pwd)" >> $GITHUB_ENV
 
     - name: Run Tests
       uses: cypress-io/github-action@v2
@@ -64,7 +70,7 @@ runs:
         tag: 'API-${{ inputs.cypress_browser }},${{ inputs.environment }}'
         record: true
         parallel: true
-        working-directory: ${{ inputs.repo_cypress_dir }}
+        working-directory: ${{ env.CYDIR }}
         ci-build-id: ${{ env.SHAGUID }}
       env:
         CYPRESS_RECORD_KEY: ${{ inputs.cypress_record_key}}

--- a/cypress-api-service-testing/run-cypress-tests/action.yaml
+++ b/cypress-api-service-testing/run-cypress-tests/action.yaml
@@ -33,6 +33,9 @@ inputs:
   cypress_record_key:
     description: 'The Cypress Dashboard Record Key'
     required: true
+  cypress_ci_build_id:
+    description: 'The ci-build-id to attach to the Cypress process. Must be unique per execution'
+    required: true
 
 runs:
   using: "composite"
@@ -67,7 +70,7 @@ runs:
         record: true
         parallel: true
         working-directory: ${{ env.CYDIR }}
-        ci-build-id: ${{ github.run_id }}
+        ci-build-id: ${{ inputs.cypress_ci_build_id }}
       env:
         CYPRESS_RECORD_KEY: ${{ inputs.cypress_record_key}}
         YARN_NODE_LINKER: pnp

--- a/cypress-api-service-testing/run-cypress-tests/action.yaml
+++ b/cypress-api-service-testing/run-cypress-tests/action.yaml
@@ -1,5 +1,5 @@
 name: 'Run Cypress Tests Vs API Service'
-description: 'Runs Terminus API Service Cypress Tests'
+description: 'Runs Terminus API Service Cypress Tests : Include env block for any environment variables needed, ex: CYPRESS_BASE_URL, CYPRESS_ts_user_email, etc'
 inputs:
   environment:
     description: 'The environment against which to run tests (ex: ninja)'
@@ -26,16 +26,13 @@ inputs:
     description: 'The browsers to test against'
     required: false
     default: 'chrome'
-  # example environment_vars:
-  # At MINIMUM CYPRESS_RECORD_KEY is required
-  # '[{"var":"CYPRESS_RECORD_KEY=''xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx''"},{"var":"CYPRESS_ts_user_email=''email@something.com''"}]'
-  environment_vars:
-    description: 'Stringified JSON array payload of environment variables to set'
-    required: true
   test_tags:
     description: 'Cypress tags to run'
     required: false
     default: '@SMOKE'
+  cypress_record_key:
+    description: 'The Cypress Dashboard Record Key'
+    required: true
 
 runs:
   using: "composite"
@@ -81,6 +78,7 @@ runs:
         working-directory: ${{ github.events.inputs.repo_cypress_dir }}
         ci-build-id: ${{ needs.prepare.outputs.uuid }}
       env:
+        CYPRESS_RECORD_KEY: ${{ github.event.inputs.cypress_record_key}}
         YARN_NODE_LINKER: pnp
         CYPRESS_grepTags: ${{ github.event.inputs.test_tags }}
         DD_ENV: ${{ github.event.inputs.environment }}

--- a/cypress-api-service-testing/run-cypress-tests/action.yaml
+++ b/cypress-api-service-testing/run-cypress-tests/action.yaml
@@ -61,7 +61,7 @@ runs:
         echo "CYDIR=$(pwd)" >> $GITHUB_ENV
 
     - name: Run Tests
-      uses: jdborneman-terminus/cypress-io-github-action@4b8d0b2d90aa41cd05cdfce5386e6e382c49a2e2
+      uses: jdborneman-terminus/cypress-io-github-action@c179631d629e64a3837ec00b2a7a1357b528592b
       with:
         config: video=true
         command-prefix: yarn

--- a/cypress-api-service-testing/run-cypress-tests/action.yaml
+++ b/cypress-api-service-testing/run-cypress-tests/action.yaml
@@ -1,0 +1,87 @@
+name: 'Run Cypress Tests Vs API Service'
+description: 'Runs Terminus API Service Cypress Tests'
+inputs:
+  environment:
+    description: 'The environment against which to run tests (ex: ninja)'
+    required: true
+  repo:
+    description: 'The repo name containing the service being tested and its tests.'
+    required: true
+  repo_owner:
+    description: 'The owner of the service/test repo'
+    required: false
+    default: 'GetTerminus'
+  repo_ref:
+    description: 'The ref to get for the service/test repo'
+    required: false
+    default: 'main'
+  repo_checkout_token:
+    description: 'The GH token that can pull down the service/test repo.'
+    required: true
+  repo_cypress_dir:
+    description: 'The directory within the service/test repo containing the Cypress tests'
+    required: false
+    default: 'cypress-e2e'
+  cypress_browser:
+    description: 'The browsers to test against'
+    required: false
+    default: 'chrome'
+  # example environment_vars:
+  # At MINIMUM CYPRESS_RECORD_KEY is required
+  # '[{"var":"CYPRESS_RECORD_KEY=''xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx''"},{"var":"CYPRESS_ts_user_email=''email@something.com''"}]'
+  environment_vars:
+    description: 'Stringified JSON array payload of environment variables to set'
+    required: true
+  test_tags:
+    description: 'Cypress tags to run'
+    required: false
+    default: '@SMOKE'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout Service
+      uses: actions/checkout@v2
+      with:
+        repository: "${{ inputs.repo_owner }}/${{ inputs.repo }}"
+        ref: ${{ inputs.repo_ref }}
+        token: ${{ inputs.repo_checkout_token }}
+
+    - name: Yarn Install
+      uses: shell
+      run: |
+        cd ${{ inputs.repo_cypress_dir }}
+        yarn install
+
+    - name: Parse Env vars
+      uses: sergeysova/jq-action@v2
+      id: environment_vars
+      with:
+        cmd: 'jq ''.[] | .var'' ${{ environment_vars }} -r'
+        multline: true
+    
+    - name: Set Env vars
+      uses: shell
+      run: |
+        environment_vars="${{ steps.environment_vars.outputs.value }}"
+        for environment_var in $environment_vars; do
+          export "$environment_var"
+        done
+
+    - name: Run Tests
+      uses: cypress-io/github-action@v2
+      with:
+        config: video=true
+        command-prefix: yarn
+        browser: ${{ github.event.inputs.cypress_browser }}
+        headless: true
+        tag: 'API-${{ github.event.inputs.cypress_browser }},${{ github.event.inputs.environment }}'
+        record: true
+        parallel: true
+        working-directory: ${{ github.events.inputs.repo_cypress_dir }}
+        ci-build-id: ${{ needs.prepare.outputs.uuid }}
+      env:
+        YARN_NODE_LINKER: pnp
+        CYPRESS_grepTags: ${{ github.event.inputs.test_tags }}
+        DD_ENV: ${{ github.event.inputs.environment }}
+        DD_SERVICE: ${{ inputs.repo }}

--- a/multi-workspace-infra/terraform-apply/action.yaml
+++ b/multi-workspace-infra/terraform-apply/action.yaml
@@ -20,22 +20,6 @@ inputs:
   artifactory_helm_chart_path:
     description: '[string] Path to helm chart for artifactory.'
     required: false
-  cypress_test_branch:
-    description: "Branch for Cypress Integration Test"
-    required: false
-  cypress_test_workflow:
-    description: "Workflow name for Cypress Integration Test"
-    required: false
-  cypress_test_repo:
-    description: "Repo name for Cypress Integration Test"
-    required: false
-  cypress_test_token:
-    description: "Token for access to Cypress Integration Test"
-    required: false
-  cypress_test_env:
-    description: "Environment to run in for Cypress Integration Test"
-    default: ninja
-    required: false
   datadog_api_key:
     description: '[secret] DataDog API Key. Required for the git-metadata upload.'
     required: false
@@ -147,15 +131,6 @@ runs:
         api_key: ${{ env.DATADOG_API_KEY }}
         app_key: ${{ env.DATADOG_APP_KEY }}
         test_search_query: 'tag:managedby:*${{ env.GITHUB_REPOSITORY }}*'
-    - name: Run Post Deploy Integration Cypress Tests
-      if: ${{ inputs.cypress_test_branch != '' && inputs.cypress_test_workflow != '' && inputs.cypress_test_repo != '' && inputs.cypress_test_token != '' && inputs.cypress_test_env != '' }}
-      uses: benc-uk/workflow-dispatch@v1
-      with:
-        ref: refs/heads/${{ inputs.cypress_test_branch }}
-        workflow: ${{ inputs.cypress_test_workflow }}
-        repo: GetTerminus/${{ inputs.cypress_test_repo }}
-        token: ${{ inputs.cypress_test_token }}
-        inputs: '{ "environment": "${{ inputs.cypress_test_env }}" }'
     - name: Deployment Success
       if: ${{ success() && inputs.use_delivery_bot == 'true' }}
       uses: deliverybot/deployment-status@v1


### PR DESCRIPTION
- [x] I promise to make sure that this PR is correct before merging it. 

### Minimal Risk Level:
#### Does this change have potential to cause downtime? 
<!-- ignore-task-list-start -->
- [x] No - This is a low risk change
- [ ] Yes - This is high risk change and must be elevated or higher and you need more approvals
<!-- ignore-task-list-end -->
### Description of Changes:

Adds a new composite action that does the following:
1. Checks out a target api service repo that contains cypress tests
2. Yarn install
3. Get working directory for the tests
4. Use cypress-io/github-action to run tests with Cypress Dashboard


Example consumption of this action can be found here: https://github.com/GetTerminus/oauth_service_infra/pull/41/files#diff-87a8eaccf2124ae84344e31dcaa819eef12f1667c979a337cb08dd74ecb31543R58