### PR TITLE
Fix:  import arguments for default vs nondefault

### DIFF
--- a/terraform-import/action.yaml
+++ b/terraform-import/action.yaml
@@ -8,7 +8,7 @@ inputs:
     description: '[decimal] [required] (i.e. 1.0.11) Terraform version to use.'
     required: true
   tf_workspace:
-    description: '[string] (i.e. ninja/prod-east) TF Workspace to create if tf_create_workspace input = true.'
+    description: '[string] (i.e. ninja/prod-east) TF Workspace to import into.'
     required: true
   resource_id:
     description: "[resource_id] [required] (i.e. 45188095) ID of the TF Resource being imported."
@@ -68,10 +68,11 @@ runs:
         RED='\033[0;31m'
         NC='\033[0m'
         printf "${RED}Below are the list of commands that will run:${NC}\n"
-        printf "%s" "terraform version"
-        printf "%s" "terraform init -lock=false -input=false"
-        printf "%s" "terraform import -input=false ${{ inputs.resource_name }} ${{ inputs.resource_id }}"
-        printf "%s" "terraform show"
+        printf "\n%s" "terraform version"
+        printf "\n%s" "terraform init -lock=false -input=false"
+        printf "\n%s" "terraform workspace select ${{ inputs.tf_workspace }}"
+        printf "\n%s" "terraform import -input=false ${{ inputs.resource_name }} ${{ inputs.resource_id }}"
+        printf "\n%s" "terraform show"
         printf "\n\n${RED}Please make sure to do the following when doing the actual import:${NC}"
         printf "\n${RED}1.${NC} Before running the import make sure you enter an empty resource in a .tf file in your root (resource \"github_repository\" \"this-is-an-example\" {})."
         printf "\n${RED}2.${NC} After the import runs successfully, search for your resource in the ${RED}Console Output${NC} and copy all of the attributes."
@@ -86,7 +87,7 @@ runs:
         if [ ${{ inputs.tf_workspace }} != "default" ]; then
           terraform import -var-file=vars/${{ inputs.tf_workspace }}.tfvars -input=false ${{ inputs.resource_name }} ${{ inputs.resource_id }}
         else
-          terraform import -var-file=vars/${{ inputs.tf_workspace }}.tfvars -input=false ${{ inputs.resource_name }} ${{ inputs.resource_id }}
+          terraform import -input=false ${{ inputs.resource_name }} ${{ inputs.resource_id }}
         fi
       shell: bash
     - name: Show Terraform State File - Find resource that was imported


### PR DESCRIPTION
Remaining work to do:  fix dry run to account for this:

```
        if [ ${{ inputs.tf_workspace }} != "default" ]; then
          terraform import -var-file=vars/${{ inputs.tf_workspace }}.tfvars -input=false ${{ inputs.resource_name }} ${{ inputs.resource_id }}
        else
          terraform import -input=false ${{ inputs.resource_name }} ${{ inputs.resource_id }}
        fi
```

Dry run right now doesn't care about flag.

We should probably find a way to go back to setting the terraform command as a part of `ENV` so that we can echo the literal commands, rather than potentially subjecting this part to copy paste errors

- [x] I promise to make sure that this PR is correct before merging it. 

### Minimal Risk Level:
#### Does this change have potential to cause downtime? 
<!-- ignore-task-list-start -->
- [x] No - This is a low risk change
- [ ] Yes - This is high risk change and must be elevated or higher and you need more approvals
<!-- ignore-task-list-end -->
### Description of Changes:
